### PR TITLE
Implement basic calendar view with task list

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,6 +11,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { ThemeProvider, useAppTheme } from '@/hooks/ThemeContext';
 import { FontSizeProvider } from '@/context/FontSizeContext';
+import { GoogleCalendarProvider } from '@/context/GoogleCalendarContext';
 import Toast from 'react-native-toast-message';
 
 import * as NavigationBar from 'expo-navigation-bar';
@@ -63,7 +64,9 @@ export default function RootLayout() {
   return (
     <ThemeProvider>
       <FontSizeProvider>
-        <InnerLayout />
+        <GoogleCalendarProvider>
+          <InnerLayout />
+        </GoogleCalendarProvider>
       </FontSizeProvider>
     </ThemeProvider>
   );

--- a/context/GoogleCalendarContext.tsx
+++ b/context/GoogleCalendarContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useState, useEffect, ReactNode, useContext } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface CalendarSyncContextType {
+  enabled: boolean;
+  setEnabled: (v: boolean) => void;
+}
+
+const CalendarSyncContext = createContext<CalendarSyncContextType>({ enabled: false, setEnabled: () => {} });
+
+const STORAGE_KEY = 'GOOGLE_CALENDAR_ENABLED';
+
+export const GoogleCalendarProvider = ({ children }: { children: ReactNode }) => {
+  const [enabled, setEnabledState] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      setEnabledState(raw === 'true');
+    })();
+  }, []);
+
+  const setEnabled = async (v: boolean) => {
+    setEnabledState(v);
+    await AsyncStorage.setItem(STORAGE_KEY, v ? 'true' : 'false');
+  };
+
+  return (
+    <CalendarSyncContext.Provider value={{ enabled, setEnabled }}>
+      {children}
+    </CalendarSyncContext.Provider>
+  );
+};
+
+export const useGoogleCalendarSync = () => useContext(CalendarSyncContext);

--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -1,51 +1,79 @@
-import React, { useRef } from 'react'
-import { View, Pressable, Animated, StyleSheet, Image } from 'react-native'
-import { useRouter } from 'expo-router'
-import testImage from '@/assets/images/k_AIOl40_400x400.jpg'
+import React, { useEffect, useState, useMemo, useCallback, useContext } from 'react';
+import { View, StyleSheet, FlatList, Text } from 'react-native';
+import { Calendar, CalendarUtils } from 'react-native-calendars';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTranslation } from 'react-i18next';
+import { useAppTheme } from '@/hooks/ThemeContext';
+import { useGoogleCalendarSync } from '@/context/GoogleCalendarContext';
+import { groupTasksByDate, createMarkedDates } from './utils';
+import { useGoogleCalendarEvents } from './useGoogleCalendar';
+import type { Task } from '@/features/tasks/types';
+import { STORAGE_KEY as TASKS_KEY } from '@/features/tasks/constants';
+import { TaskItem } from '@/features/tasks/components/TaskItem';
 
 export default function CalendarScreen() {
-  const router = useRouter()
-  const scaleAnim = useRef(new Animated.Value(1)).current
+  const { t, i18n } = useTranslation();
+  const { colorScheme, subColor } = useAppTheme();
+  const { enabled: googleEnabled } = useGoogleCalendarSync();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [selectedDate, setSelectedDate] = useState<string>(CalendarUtils.getCalendarDateString(new Date()));
 
-  const onPressIn = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 0.9,
-      useNativeDriver: true,
-    }).start()
-  }
+  useEffect(() => {
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(TASKS_KEY);
+        setTasks(raw ? JSON.parse(raw) : []);
+      } catch {
+        setTasks([]);
+      }
+    })();
+  }, []);
 
-  const onPressOut = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 1,
-      friction: 3,
-      useNativeDriver: true,
-    }).start(() => {
-      router.replace('/tasks') // ✅ 修正後
-    })
-  }
+  const grouped = useMemo(() => groupTasksByDate(tasks), [tasks]);
+  const marked = useMemo(
+    () => createMarkedDates(grouped, selectedDate, i18n.language, subColor),
+    [grouped, selectedDate, i18n.language, subColor]
+  );
+
+  const googleEvents = useGoogleCalendarEvents(selectedDate, googleEnabled);
+  const dayTasks = grouped[selectedDate] || [];
+
+  const renderTask = useCallback(({ item }: { item: Task }) => (
+    <TaskItem task={{ ...item, keyId: item.id, displaySortDate: undefined, isTaskFullyCompleted: !!item.completedAt }}
+      onToggle={() => {}}
+      isSelecting={false}
+      selectedIds={[]}
+      onLongPressSelect={() => {}}
+      currentTab="incomplete"
+    />
+  ), []);
 
   return (
-    <View style={styles.container}>
-      <Pressable onPressIn={onPressIn} onPressOut={onPressOut}>
-        <Animated.Image
-          source={testImage} // ✅ 修正後
-          style={[styles.image, { transform: [{ scale: scaleAnim }] }]}
-        />
-      </Pressable>
+    <View style={[styles.container, { backgroundColor: colorScheme === 'dark' ? '#000' : '#fff' }]}>
+      <Calendar
+        markedDates={marked}
+        onDayPress={day => setSelectedDate(day.dateString)}
+        theme={{
+          calendarBackground: colorScheme === 'dark' ? '#000' : '#fff',
+          dayTextColor: colorScheme === 'dark' ? '#fff' : '#000',
+          monthTextColor: subColor,
+          textDayFontWeight: '500',
+        }}
+      />
+      <FlatList
+        data={dayTasks}
+        keyExtractor={item => item.id}
+        renderItem={renderTask}
+        ListHeaderComponent={googleEvents.length > 0 ? (
+          <View style={styles.googleHeader}><Text style={styles.googleHeaderText}>Google</Text></View>
+        ) : null}
+      />
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#fff',
-  },
-  image: {
-    width: 120,
-    height: 120,
-    resizeMode: 'contain',
-  },
-})
+  container: { flex: 1 },
+  googleHeader: { padding: 8 },
+  googleHeaderText: { fontWeight: '600' },
+});

--- a/features/calendar/useGoogleCalendar.ts
+++ b/features/calendar/useGoogleCalendar.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export type GoogleEvent = {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+};
+
+export const useGoogleCalendarEvents = (date: string, enabled: boolean) => {
+  const [events, setEvents] = useState<GoogleEvent[]>([]);
+
+  useEffect(() => {
+    if (!enabled) { setEvents([]); return; }
+    // TODO: Implement real Google Calendar API integration
+    setEvents([]);
+  }, [date, enabled]);
+
+  return events;
+};

--- a/features/calendar/utils.ts
+++ b/features/calendar/utils.ts
@@ -1,0 +1,50 @@
+import dayjs from 'dayjs';
+import { MarkedDates } from 'react-native-calendars';
+import { isHoliday } from '@holiday-jp/holiday_jp';
+import type { Task } from '@/features/tasks/types';
+import { calculateActualDueDate, calculateNextDisplayInstanceDate } from '@/features/tasks/utils';
+
+export const groupTasksByDate = (tasks: Task[]): Record<string, Task[]> => {
+  const map: Record<string, Task[]> = {};
+  const add = (date: dayjs.Dayjs | null, task: Task) => {
+    if (!date) return;
+    const key = date.local().format('YYYY-MM-DD');
+    if (!map[key]) map[key] = [];
+    map[key].push(task);
+  };
+
+  tasks.forEach(task => {
+    if (task.deadlineDetails?.repeatFrequency) {
+      task.completedInstanceDates?.forEach(d => add(dayjs.utc(d), task));
+      add(calculateNextDisplayInstanceDate(task), task);
+    } else {
+      add(calculateActualDueDate(task), task);
+    }
+  });
+
+  return map;
+};
+
+export const createMarkedDates = (
+  grouped: Record<string, Task[]>,
+  selected: string,
+  language: string,
+  subColor: string
+): MarkedDates => {
+  const marks: MarkedDates = {};
+  Object.keys(grouped).forEach(date => {
+    marks[date] = { marked: true, dotColor: subColor };
+  });
+  if (language.startsWith('ja')) {
+    const month = dayjs(selected).startOf('month');
+    const end = dayjs(selected).endOf('month');
+    for (let d = month; d.isBefore(end.add(1, 'day')); d = d.add(1, 'day')) {
+      const ds = d.format('YYYY-MM-DD');
+      if (isHoliday(new Date(ds))) {
+        marks[ds] = { ...(marks[ds] || {}), marked: true, dotColor: 'red' };
+      }
+    }
+  }
+  marks[selected] = { ...(marks[selected] || {}), selected: true };
+  return marks;
+};

--- a/features/settings/SettingsScreen.tsx
+++ b/features/settings/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   useWindowDimensions,
   Platform, // Platform をインポート
+  Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppTheme, ThemeChoice } from '@/hooks/ThemeContext';
@@ -18,6 +19,7 @@ import Slider from '@react-native-community/slider';
 import { FontSizeContext, FontSizeKey } from '@/context/FontSizeContext';
 import { fontSizes } from '@/constants/fontSizes';
 import { Ionicons } from '@expo/vector-icons'; // Ionicons をインポート
+import { useGoogleCalendarSync } from '@/context/GoogleCalendarContext';
 
 export default function SettingsScreen() {
   const {
@@ -28,6 +30,7 @@ export default function SettingsScreen() {
     setSubColor,
   } = useAppTheme();
   const { fontSizeKey, setFontSizeKey } = useContext(FontSizeContext);
+  const { enabled: googleSyncEnabled, setEnabled: setGoogleSyncEnabled } = useGoogleCalendarSync();
   const { t } = useTranslation();
   const router = useRouter();
   const isDark = colorScheme === 'dark';
@@ -170,6 +173,19 @@ export default function SettingsScreen() {
           </TouchableOpacity>
         </View>
         {/* --- 繰り返しタスクの設定項目ここまで --- */}
+
+        <View style={styles.card}>
+          <Text style={styles.label}>{t('settings.google_calendar_integration', 'Googleカレンダー連携')}</Text>
+          <View style={styles.optionRowButton}>
+            <Text style={styles.optionLabel}>{googleSyncEnabled ? t('common.enabled', '有効') : t('common.disabled', '無効')}</Text>
+            <Switch
+              value={googleSyncEnabled}
+              onValueChange={setGoogleSyncEnabled}
+              thumbColor={Platform.OS === 'android' ? subColor : undefined}
+              trackColor={{ false: isDark ? '#767577' : '#ccc', true: subColor }}
+            />
+          </View>
+        </View>
 
       </ScrollView>
     </SafeAreaView>

--- a/locales/en.json
+++ b/locales/en.json
@@ -24,7 +24,8 @@
     "font_size_small": "Small",
     "font_size_normal": "Medium",
     "font_size_medium": "Normal",
-    "font_size_large": "Large"
+    "font_size_large": "Large",
+    "google_calendar_integration": "Google Calendar Integration"
   },
   "common": {
     "loading": "Loading...",
@@ -32,6 +33,8 @@
     "delete": "Delete",
     "save": "Save",
     "ok": "OK",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
     "select": "Select",
     "select_all": "Select All",
     "year_unit": "Yr",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -33,7 +33,8 @@
     "stop_repeating_confirm_title": "繰り返しの解除",
     "stop_repeating_confirm_message": "このタスクの繰り返し設定を解除しますか？\nタスク自体は削除されません。",
     "stop_action": "解除する",
-    "view_task_details_tooltip": "タスク詳細を見る"
+    "view_task_details_tooltip": "タスク詳細を見る",
+    "google_calendar_integration": "Googleカレンダー連携"
   },
   "common": {
     "loading": "読み込み中...",
@@ -41,6 +42,8 @@
     "delete": "削除",
     "save": "保存",
     "ok": "OK",
+    "enabled": "有効",
+    "disabled": "無効",
     "select": "選択",
     "select_all": "全選択",
     "year_unit": "年",


### PR DESCRIPTION
## Summary
- create GoogleCalendarContext for sync settings
- show calendar with task markings and daily task list
- add Google Calendar toggle in Settings
- include translations for the new setting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414424408c83269d9ed2995a71babc