### PR TITLE
Improve calendar screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ In the output, you'll find options to open the app in a
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
+### Google Calendar integration
+
+To display events from Google Calendar, set the environment variable `EXPO_PUBLIC_GOOGLE_CALENDAR_ICS_URL` to the public iCalendar URL of the calendar. When `Googleカレンダー連携` is enabled in the settings screen, events for the selected day will appear above the task list.
+
 ## Get a fresh project
 
 When you're ready, run:

--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -39,7 +39,8 @@ export default function CalendarScreen() {
   const dayTasks = grouped[selectedDate] || [];
 
   const renderTask = useCallback(({ item }: { item: Task }) => (
-    <TaskItem task={{ ...item, keyId: item.id, displaySortDate: undefined, isTaskFullyCompleted: !!item.completedAt }}
+    <TaskItem
+      task={{ ...item, keyId: item.id, displaySortDate: undefined, isTaskFullyCompleted: !!item.completedAt }}
       onToggle={() => {}}
       isSelecting={false}
       selectedIds={[]}
@@ -47,6 +48,18 @@ export default function CalendarScreen() {
       currentTab="incomplete"
     />
   ), []);
+
+  const renderHeader = useCallback(() => {
+    if (googleEvents.length === 0) return null;
+    return (
+      <View style={styles.googleHeader}>
+        <Text style={styles.googleHeaderText}>Google</Text>
+        {googleEvents.map(ev => (
+          <Text key={ev.id} style={styles.googleEvent}>{ev.title}</Text>
+        ))}
+      </View>
+    );
+  }, [googleEvents]);
 
   return (
     <View style={[styles.container, { backgroundColor: colorScheme === 'dark' ? '#000' : '#fff' }]}>
@@ -64,9 +77,7 @@ export default function CalendarScreen() {
         data={dayTasks}
         keyExtractor={item => item.id}
         renderItem={renderTask}
-        ListHeaderComponent={googleEvents.length > 0 ? (
-          <View style={styles.googleHeader}><Text style={styles.googleHeaderText}>Google</Text></View>
-        ) : null}
+        ListHeaderComponent={renderHeader}
       />
     </View>
   );
@@ -76,4 +87,5 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   googleHeader: { padding: 8 },
   googleHeaderText: { fontWeight: '600' },
+  googleEvent: { paddingLeft: 8, paddingTop: 2 },
 });

--- a/features/calendar/useGoogleCalendar.ts
+++ b/features/calendar/useGoogleCalendar.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
 
 export type GoogleEvent = {
   id: string;
@@ -12,9 +13,55 @@ export const useGoogleCalendarEvents = (date: string, enabled: boolean) => {
 
   useEffect(() => {
     if (!enabled) { setEvents([]); return; }
-    // TODO: Implement real Google Calendar API integration
-    setEvents([]);
+    const url = process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_ICS_URL;
+    if (!url) { setEvents([]); return; }
+    const fetchEvents = async () => {
+      try {
+        const res = await fetch(url);
+        const text = await res.text();
+        const parsed = parseICal(text);
+        const filtered = parsed.filter(ev => dayjs(ev.start).format('YYYY-MM-DD') === date);
+        setEvents(filtered);
+      } catch {
+        setEvents([]);
+      }
+    };
+    fetchEvents();
   }, [date, enabled]);
 
   return events;
+};
+
+const parseICal = (ics: string): GoogleEvent[] => {
+  const events: GoogleEvent[] = [];
+  const lines = ics.split(/\r?\n/);
+  let current: Partial<GoogleEvent> | null = null;
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      current = {};
+    } else if (line === 'END:VEVENT') {
+      if (current && current.id && current.start && current.end && current.title) {
+        events.push(current as GoogleEvent);
+      }
+      current = null;
+    } else if (current) {
+      if (line.startsWith('UID')) {
+        current.id = line.substring(line.indexOf(':') + 1);
+      } else if (line.startsWith('SUMMARY')) {
+        current.title = line.substring(line.indexOf(':') + 1);
+      } else if (line.startsWith('DTSTART')) {
+        current.start = icsDateToISO(line.substring(line.indexOf(':') + 1));
+      } else if (line.startsWith('DTEND')) {
+        current.end = icsDateToISO(line.substring(line.indexOf(':') + 1));
+      }
+    }
+  }
+  return events;
+};
+
+const icsDateToISO = (str: string): string => {
+  if (str.length === 8) {
+    return dayjs(str, 'YYYYMMDD').toISOString();
+  }
+  return dayjs(str.replace(/Z$/, ''), 'YYYYMMDDTHHmmss').toISOString();
 };


### PR DESCRIPTION
## Summary
- integrate Google Calendar events via iCalendar feed
- display fetched events above the task list
- document how to set `EXPO_PUBLIC_GOOGLE_CALENDAR_ICS_URL`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684153867e9883269eed915aab79e54b